### PR TITLE
REV-94/router 세팅

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,8 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools'
+import { RouterProvider } from 'react-router-dom'
 import { worker } from './mocks'
+import { router } from './routes'
 
 if (process.env.NODE_ENV === 'development') {
   worker.start()
@@ -11,7 +13,7 @@ const queryClient = new QueryClient()
 function App() {
   return (
     <QueryClientProvider client={queryClient}>
-      {/* The rest of your application */}
+      <RouterProvider router={router} />
       <ReactQueryDevtools initialIsOpen={false} />
     </QueryClientProvider>
   )

--- a/src/routes/Layout.tsx
+++ b/src/routes/Layout.tsx
@@ -2,7 +2,7 @@ import { Outlet } from 'react-router-dom'
 
 const Layout = () => {
   return (
-    <div className="mx-auto h-screen max-w-[767px] border border-black md:max-w-[880px]">
+    <div className="mx-auto h-screen max-w-[767px] border border-black dark:border-white dark:bg-[#202020] md:max-w-[880px]">
       <Outlet />
     </div>
   )

--- a/src/routes/Layout.tsx
+++ b/src/routes/Layout.tsx
@@ -1,0 +1,11 @@
+import { Outlet } from 'react-router-dom'
+
+const Layout = () => {
+  return (
+    <div className="mx-auto h-screen max-w-[767px] border border-black md:max-w-[880px]">
+      <Outlet />
+    </div>
+  )
+}
+
+export default Layout

--- a/src/routes/constants.ts
+++ b/src/routes/constants.ts
@@ -1,0 +1,10 @@
+export const PATH = {
+  MAIN: '/',
+  SIGN_UP: '/sign-up',
+  LOGIN: '/login',
+  PROFILE: '/profile',
+  REVIEW_MANAGEMENT: '/review-management:reviewId',
+  REVIEW_RESPONSE: '/review-response/:reviewId',
+  REVIEW_RESULT: '/review-result/:reviewId',
+  REVIEW_CREATION: '/review-creation',
+}

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -1,0 +1,1 @@
+export { default as router } from './router'

--- a/src/routes/router.tsx
+++ b/src/routes/router.tsx
@@ -1,0 +1,56 @@
+import { createBrowserRouter } from 'react-router-dom'
+import {
+  CreatedReviewManagePage,
+  LoginPage,
+  MainPage,
+  MyPage,
+  ReviewCreatePage,
+  ReviewReplyPage,
+  ReviewResultPage,
+  SignUpPage,
+} from '@/pages'
+import Layout from './Layout'
+import { PATH } from './constants'
+
+const router = createBrowserRouter([
+  {
+    path: PATH.MAIN,
+    element: <Layout />,
+    children: [
+      {
+        path: PATH.MAIN,
+        element: <MainPage />,
+      },
+      {
+        path: PATH.SIGN_UP,
+        element: <SignUpPage />,
+      },
+      {
+        path: PATH.LOGIN,
+        element: <LoginPage />,
+      },
+      {
+        path: PATH.REVIEW_CREATION,
+        element: <ReviewCreatePage />,
+      },
+      {
+        path: PATH.REVIEW_MANAGEMENT,
+        element: <CreatedReviewManagePage />,
+      },
+      {
+        path: PATH.REVIEW_RESPONSE,
+        element: <ReviewReplyPage />,
+      },
+      {
+        path: PATH.REVIEW_RESULT,
+        element: <ReviewResultPage />,
+      },
+      {
+        path: PATH.PROFILE,
+        element: <MyPage />,
+      },
+    ],
+  },
+])
+
+export default router

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -6,8 +6,5 @@ export default {
   theme: {
     extend: {},
   },
-  rippleui: {
-    removeThemes: ['dark'],
-  },
   plugins: [rippleui],
 }


### PR DESCRIPTION
## 📑 구현 내용 <!-- 스크린샷, 시연 영상 및 설명 작성 -->

라우터를 세팅했습니다.

<br/>

## 🚧 참고 사항

### 레이아웃 width

<img src='https://github.com/prgrms-web-devcourse/Team-12-ReviewRanger-FE/assets/97094709/2fa15534-5784-4dc2-80a8-3d6d2243382e' width='600' />

레이아웃은 데스크탑과 태블릿&모바일 크기에 맞게 지정했습니다.
데스크탑에서는 사용자가 한눈에 보기 편하게 최대 너비를 880px로 지정했습니다.
그 외에는 모바일 최대 너비인 767px로 했습니다.

개발할 때 구분하기 쉽게 border를 지정해줬습니다. 이건 개발 다 완료하면 제거하면 됩니다!

<br/>

### 다크모드 재적용

디자인 할 때 다크모드도 한꺼번에 하게 돼서, tailwind에 다크모드를 다시 살렸습니다.
다크모드일 때 스타일을 적용하고 싶다면 `dark:bg-gray-100` 이런 식으로 prefix를 붙이면 됩니다!

🚨 이제 **다크모드 토글 버튼**(일단 개발용 버튼)을 구현해야할 것 같습니다.  이건 context api로 구현할 수 있을 것 같아요!
이번 스프린트 때 시간이 남으면 구현해도 좋을 것 같습니다!! [관련 링크](https://velog.io/@skgmlsla/Context-API%EB%A1%9C-%EB%8B%A4%ED%81%AC%EB%AA%A8%EB%93%9C-%EA%B5%AC%ED%98%84)

<br/>

### router 상수

```ts
export const PATH = {
  MAIN: '/',
  SIGN_UP: '/sign-up',
  LOGIN: '/login',
  PROFILE: '/profile',
  REVIEW_MANAGEMENT: '/review-management:reviewId',
  REVIEW_RESPONSE: '/review-response/:reviewId',
  REVIEW_RESULT: '/review-result/:reviewId',
  REVIEW_CREATION: '/review-creation',
}
```
상수를 이렇게 정의해봤습니다. :reviewId를 붙일까 말까 고민했는데, 새로고침 시 남아있으면 좋을 것 같아서 붙였습니다!

또한 페이지 컴포넌트 파일과 저희 실제 페이지의 url은 상이합니다. 
예를 들어 랜딩 페이지 컴포넌트 파일은 존재하지만 url은 없습니다.
이유는 처음 방문 시 따로 링크 이동 없이 보여주는 페이지이기 때문입니다!

<br/>

### 에러 바운더리, 서스펜스, 리다이렉트, 스크롤탑 등

에러나 로딩중 상태 처리,
존재하는 path 값인데 토큰이 맞지 않거나 잘못된 접근일 경우 메인 페이지로 이동하는 리다이렉트 처리,
페이지 이동마다 스크롤을 가장 위로 올리는 처리 등은
추후에 더 알아보고 진행하면 좋을 것 같습니다!

<br/>

<!-- ## ❓ 궁금한 점 -->
