### PR TITLE
REV-268/메인페이지 백엔드 api 연동

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,12 +2,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools'
 import { RouterProvider } from 'react-router-dom'
 import { ThemeProvider } from './components'
-import { worker } from './mocks'
 import { router } from './routes'
-
-if (process.env.NODE_ENV === 'development') {
-  worker.start()
-}
 
 const queryClient = new QueryClient()
 

--- a/src/apis/hooks/useGetAllReviews.ts
+++ b/src/apis/hooks/useGetAllReviews.ts
@@ -2,30 +2,56 @@ import { useSuspenseQueries } from '@tanstack/react-query'
 import { CreatedReview, InvitedReview, ReceivedReview } from '@/types'
 import apiClient from '../apiClient'
 
+interface InvitedReviewResponse {
+  success: boolean
+  data: {
+    content: InvitedReview[]
+    last: boolean
+  }
+}
+
+interface CreatedReviewResponse {
+  success: boolean
+  data: {
+    content: CreatedReview[]
+    last: boolean
+  }
+}
+
+interface ReceivedReviewResponse {
+  success: boolean
+  data: {
+    content: ReceivedReview[]
+    last: boolean
+  }
+}
+
 const useGetAllReviews = () => {
   const getInvitedReview = async () => {
-    const response = await apiClient.get<InvitedReview[]>('/invited-surveys')
+    const response =
+      await apiClient.get<InvitedReviewResponse>('/participations')
 
-    return response.data
+    return response.data.data
   }
 
   const getCreatedReview = async () => {
-    const response = await apiClient.get<CreatedReview[]>('/created-surveys')
+    const response = await apiClient.get<CreatedReviewResponse>('/reviews')
 
-    return response.data
+    return response.data.data
   }
 
   const getReceivedReview = async () => {
-    const response = await apiClient.get<ReceivedReview[]>('/received-reviews')
+    const response =
+      await apiClient.get<ReceivedReviewResponse>('/final-results')
 
-    return response.data
+    return response.data.data
   }
 
   return useSuspenseQueries({
     queries: [
-      { queryKey: ['/created-surveys'], queryFn: getInvitedReview },
-      { queryKey: ['/received-reviews'], queryFn: getCreatedReview },
-      { queryKey: ['/invited-surveys'], queryFn: getReceivedReview },
+      { queryKey: ['/participations'], queryFn: getInvitedReview },
+      { queryKey: ['/reviews'], queryFn: getCreatedReview },
+      { queryKey: ['/final-results'], queryFn: getReceivedReview },
     ],
   })
 }

--- a/src/pages/MainPage/components/CreatedReviewItem/index.tsx
+++ b/src/pages/MainPage/components/CreatedReviewItem/index.tsx
@@ -1,7 +1,7 @@
 import dayjs from 'dayjs'
 import { MenuIcon } from '@/assets/icons'
 import { CreatedReview } from '@/types'
-import { STATUS_STYLE } from '../../constants'
+import { STATUS, STATUS_STYLE } from '../../constants'
 
 interface CreatedReviewItemProps extends CreatedReview {
   className: string
@@ -30,7 +30,7 @@ const CreatedReviewItem = ({
           <span
             className={`${STATUS_STYLE[status]} rounded-full px-1.5 py-0.5 text-xs text-white md:text-sm`}
           >
-            {status}
+            {STATUS[status]}
           </span>
           {newStatus && (
             <span className="rounded-full bg-sub-red-200 px-1.5 py-0.5 text-xs text-white md:text-sm">

--- a/src/pages/MainPage/components/CreatedReviewItem/index.tsx
+++ b/src/pages/MainPage/components/CreatedReviewItem/index.tsx
@@ -9,7 +9,7 @@ interface CreatedReviewItemProps extends CreatedReview {
 }
 
 const CreatedReviewItem = ({
-  id,
+  reviewId,
   title,
   status,
   responserCount,
@@ -17,14 +17,14 @@ const CreatedReviewItem = ({
   className,
   handleReviewClick,
 }: CreatedReviewItemProps) => {
-  console.log(`${id}번 리뷰의 응답자 수: ${responserCount}명`)
+  console.log(`${reviewId}번 리뷰의 응답자 수: ${responserCount}명`)
 
   /** 최근 7일 이내 생성된 데이터인지 여부 */
   const newStatus =
     createdAt && dayjs(createdAt).isAfter(dayjs().subtract(7, 'day'))
 
   return (
-    <div className={className} onClick={() => handleReviewClick(id)}>
+    <div className={className} onClick={() => handleReviewClick(reviewId)}>
       <div className="flex items-center justify-between">
         <div className="flex gap-1.5">
           <span

--- a/src/pages/MainPage/components/InvitedReviewItem/index.tsx
+++ b/src/pages/MainPage/components/InvitedReviewItem/index.tsx
@@ -1,6 +1,6 @@
 import dayjs from 'dayjs'
 import { InvitedReview } from '@/types'
-import { STATUS_STYLE } from '../../constants'
+import { STATUS, STATUS_STYLE } from '../../constants'
 
 interface InvitedReviewItemProps extends InvitedReview {
   className: string
@@ -30,7 +30,7 @@ const InvitedReviewItem = ({
         <span
           className={`${STATUS_STYLE[status]} rounded-full px-1.5 py-0.5 text-xs text-white md:text-sm`}
         >
-          {status}
+          {STATUS[status]}
         </span>
         {newStatus && (
           <span className="rounded-full bg-sub-red-200 px-1.5 py-0.5 text-xs text-white md:text-sm">

--- a/src/pages/MainPage/components/InvitedReviewItem/index.tsx
+++ b/src/pages/MainPage/components/InvitedReviewItem/index.tsx
@@ -8,11 +8,11 @@ interface InvitedReviewItemProps extends InvitedReview {
 }
 
 const InvitedReviewItem = ({
-  id,
+  participationId,
   title,
   status,
-  isCompleted,
   createdAt,
+  submitAt,
   className,
   handleReviewClick,
 }: InvitedReviewItemProps) => {
@@ -22,7 +22,10 @@ const InvitedReviewItem = ({
     createdAt && dayjs(createdAt).isAfter(dayjs().subtract(7, 'day'))
 
   return (
-    <div className={className} onClick={() => handleReviewClick(id)}>
+    <div
+      className={className}
+      onClick={() => handleReviewClick(participationId)}
+    >
       <div className="flex gap-1.5">
         <span
           className={`${STATUS_STYLE[status]} rounded-full px-1.5 py-0.5 text-xs text-white md:text-sm`}
@@ -41,13 +44,13 @@ const InvitedReviewItem = ({
       </p>
       <p
         className={`text-right text-xs md:text-sm ${
-          isCompleted
+          submitAt
             ? 'text-black dark:text-sub-red-100'
             : 'text-sub-red-200 dark:text-sub-yellow'
         }`}
       >
-        {isCompleted
-          ? `응답일: ${dayjs(createdAt).format('YYYY-MM-DD')}`
+        {submitAt
+          ? `응답일: ${dayjs(submitAt).format('YYYY-MM-DD')}`
           : '미응답'}
       </p>
     </div>

--- a/src/pages/MainPage/components/ReviewList/index.tsx
+++ b/src/pages/MainPage/components/ReviewList/index.tsx
@@ -1,3 +1,4 @@
+import { nanoid } from 'nanoid'
 import { useNavigate } from 'react-router-dom'
 import { PlusIcon } from '@/assets/icons'
 import { CreatedReview, InvitedReview, ReceivedReview } from '@/types'
@@ -34,7 +35,7 @@ const ReviewList = ({
 
       {reviews.map((review) => (
         <RenderComponent
-          key={review.id}
+          key={nanoid()}
           className="btn flex h-36 flex-col items-stretch justify-between rounded-sm border border-gray-100 bg-main-ivory p-2.5 transition-transform dark:border-white dark:bg-main-red-200 md:h-44"
           {...review}
         />

--- a/src/pages/MainPage/constants.ts
+++ b/src/pages/MainPage/constants.ts
@@ -25,9 +25,15 @@ export const INTRO_STYLE = {
   received: 'text-sub-orange dark:text-sub-yellow',
 }
 
+export const STATUS = {
+  PROCEEDING: '진행중',
+  DEADLINE: '마감',
+  END: '종료',
+}
+
 export const STATUS_STYLE = {
-  DEADLINE: 'bg-sub-green',
-  PROCEEDING: 'bg-sub-brown',
+  PROCEEDING: 'bg-sub-green',
+  DEADLINE: 'bg-sub-brown',
   END: 'bg-gray-300',
 }
 

--- a/src/pages/MainPage/constants.ts
+++ b/src/pages/MainPage/constants.ts
@@ -26,9 +26,9 @@ export const INTRO_STYLE = {
 }
 
 export const STATUS_STYLE = {
-  진행중: 'bg-sub-green',
-  마감: 'bg-sub-brown',
-  종료: 'bg-gray-300',
+  DEADLINE: 'bg-sub-green',
+  PROCEEDING: 'bg-sub-brown',
+  END: 'bg-gray-300',
 }
 
 export const TAB_MENU_TITLE = {

--- a/src/pages/MainPage/index.tsx
+++ b/src/pages/MainPage/index.tsx
@@ -24,9 +24,9 @@ const MainPage = () => {
   >('invited')
 
   const TAB_REVIEWS = {
-    invited: invitedReviews,
-    created: createdReviews,
-    received: receivedReviews,
+    invited: invitedReviews.content,
+    created: createdReviews.content,
+    received: receivedReviews.content,
   }
 
   const handleInvitedReviewClick = (id: number) => {
@@ -66,7 +66,7 @@ const MainPage = () => {
           reviews={TAB_REVIEWS[activeTab]}
           addButtonExistence={activeTab === 'created'}
           RenderComponent={(review) => {
-            if ('isCompleted' in review) {
+            if ('submitAt' in review) {
               return (
                 <InvitedReviewItem
                   {...review}

--- a/src/routes/router.tsx
+++ b/src/routes/router.tsx
@@ -1,3 +1,4 @@
+import { Suspense } from 'react'
 import { createBrowserRouter } from 'react-router-dom'
 import {
   CreatedReviewManagePage,
@@ -21,7 +22,11 @@ const router = createBrowserRouter([
     children: [
       {
         path: PATH.MAIN,
-        element: <MainPage />,
+        element: (
+          <Suspense>
+            <MainPage />
+          </Suspense>
+        ),
         loader: loginLoader,
       },
       {
@@ -36,7 +41,11 @@ const router = createBrowserRouter([
       },
       {
         path: PATH.REVIEW_CREATION,
-        element: <ReviewCreatePage />,
+        element: (
+          <Suspense>
+            <ReviewCreatePage />
+          </Suspense>
+        ),
         loader: loginLoader,
       },
       {

--- a/src/types/reviews.ts
+++ b/src/types/reviews.ts
@@ -1,18 +1,26 @@
+export type ReviewStatus = 'DEADLINE' | 'PROCEEDING' | 'END'
+
+export type QuestionType =
+  | 'SINGLE_CHOICE'
+  | 'MULTIPLE_CHOICE'
+  | 'RATING'
+  | 'SUBJECTIVE'
+  | 'DROPDOWN'
+  | 'HEXASTAT'
+
 export interface InvitedReview {
-  id: number
+  participationId: number
+  status: ReviewStatus
   title: string
-  status: '진행중' | '마감' | '종료'
-  type: string
-  isCompleted: boolean
-  createdAt: string | null
+  createdAt: string
+  submitAt: string
 }
 
 export interface CreatedReview {
-  id: number
+  reviewId: number
+  status: ReviewStatus
   title: string
-  status: '진행중' | '마감' | '종료'
   responserCount: number
-  type: string
   createdAt: string
 }
 


### PR DESCRIPTION
## 📑 구현 내용 <!-- 스크린샷, 시연 영상 및 설명 작성 -->
<img src='https://github.com/prgrms-web-devcourse/Team-12-ReviewRanger-FE/assets/97094709/80752b09-d552-442f-a2ea-73421b85cfee' width='400' />

![image](https://github.com/prgrms-web-devcourse/Team-12-ReviewRanger-FE/assets/97094709/c5f5e8a5-868c-4198-8840-fec6fb347ef7)
![image](https://github.com/prgrms-web-devcourse/Team-12-ReviewRanger-FE/assets/97094709/d01f2bfe-bde1-4de4-b585-2a6974c9d8ab)
로그인 후 응답이 잘 내려옵니다!

<br/>

## 🚧 참고 사항

### 토큰 에러 ..

- 한 몇십초 지나면 유효하지 않은 토큰이라고 서버 에러가 뜹니다.

### 추후에 추가할 기능들

- [`useSuspenseInfiniteQuery`](https://tanstack.com/query/v5/docs/react/reference/useSuspenseInfiniteQuery) 로 바꾸고 무한 스크롤을 적용할 예정입니다!
  -  지금 하려고 했는데, 그냥 티켓을 더 작게 쪼개는 게 나을 거 같아요! 
- 각각 리뷰 아이템을 누르면 해당하는 링크로 이동하도록 추가할 예정입니다.
- 피그마에 수정된 스타일을 반영하겠습니다.

<br/>

<!-- ## ❓ 궁금한 점 -->
