### PR TITLE
REV-269/리뷰 생성 페이지 백엔드 api 연동

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,12 +2,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools'
 import { RouterProvider } from 'react-router-dom'
 import { ThemeProvider } from './components'
-import { worker } from './mocks'
 import { router } from './routes'
-
-if (process.env.NODE_ENV === 'development') {
-  worker.start()
-}
 
 const queryClient = new QueryClient()
 

--- a/src/pages/ReviewCreatePage/components/QuestionItem/index.tsx
+++ b/src/pages/ReviewCreatePage/components/QuestionItem/index.tsx
@@ -113,8 +113,12 @@ const QuestionItem = ({
 
         <textarea
           placeholder="질문에 대한 설명을 입력해주세요."
-          className="mt-4 w-full border border-gray-200 bg-white p-2.5 text-sm text-black outline-none placeholder:text-gray-100 dark:bg-main-gray dark:text-white md:text-base"
+          className="mt-4 h-24 w-full border border-gray-200 bg-white p-2.5 text-sm text-black outline-none placeholder:text-gray-100 dark:bg-main-gray dark:text-white md:text-base"
           {...register(`questions.${index}.description`, {
+            maxLength: {
+              value: 200,
+              message: '200자 이내로 작성해주세요.',
+            },
             setValueAs: (value: string) => value.trim(),
           })}
           onKeyUp={(e) => {
@@ -124,6 +128,11 @@ const QuestionItem = ({
             e.preventDefault()
           }}
         />
+        {errors.questions?.[index]?.description && (
+          <p className="mt-1 text-xs text-sub-red-200 dark:text-sub-yellow md:text-sm">
+            {errors.questions?.[index]?.description?.message}
+          </p>
+        )}
       </div>
 
       {(type === 'SINGLE_CHOICE' ||

--- a/src/pages/ReviewCreatePage/components/QuestionItem/index.tsx
+++ b/src/pages/ReviewCreatePage/components/QuestionItem/index.tsx
@@ -98,11 +98,10 @@ const QuestionItem = ({
             },
             setValueAs: (value: string) => value.trim(),
           })}
-          onKeyUp={(e) => {
-            if (e.key) {
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') {
               e.preventDefault()
             }
-            e.preventDefault()
           }}
         />
         {errors.questions?.[index]?.title && (
@@ -121,12 +120,6 @@ const QuestionItem = ({
             },
             setValueAs: (value: string) => value.trim(),
           })}
-          onKeyUp={(e) => {
-            if (e.key) {
-              e.preventDefault()
-            }
-            e.preventDefault()
-          }}
         />
         {errors.questions?.[index]?.description && (
           <p className="mt-1 text-xs text-sub-red-200 dark:text-sub-yellow md:text-sm">

--- a/src/pages/ReviewCreatePage/components/QuestionItem/index.tsx
+++ b/src/pages/ReviewCreatePage/components/QuestionItem/index.tsx
@@ -110,6 +110,20 @@ const QuestionItem = ({
             {errors.questions?.[index]?.title?.message}
           </p>
         )}
+
+        <textarea
+          placeholder="질문에 대한 설명을 입력해주세요."
+          className="mt-4 w-full border border-gray-200 bg-white p-2.5 text-sm text-black outline-none placeholder:text-gray-100 dark:bg-main-gray dark:text-white md:text-base"
+          {...register(`questions.${index}.description`, {
+            setValueAs: (value: string) => value.trim(),
+          })}
+          onKeyUp={(e) => {
+            if (e.key) {
+              e.preventDefault()
+            }
+            e.preventDefault()
+          }}
+        />
       </div>
 
       {(type === 'SINGLE_CHOICE' ||

--- a/src/pages/ReviewCreatePage/components/QuestionTypeModal/index.tsx
+++ b/src/pages/ReviewCreatePage/components/QuestionTypeModal/index.tsx
@@ -27,6 +27,7 @@ const QuestionTypeModal = ({ append }: QuestionTypeModalProps) => {
 
     append({
       title: '',
+      description: '',
       type,
       isRequired: true,
       questionOptions,

--- a/src/pages/ReviewCreatePage/components/ResponserSelect/index.tsx
+++ b/src/pages/ReviewCreatePage/components/ResponserSelect/index.tsx
@@ -52,7 +52,7 @@ const ResponserSelect = ({ handleClickButton }: ResponserSelectProps) => {
   return (
     <>
       <form
-        className="mx-auto flex h-full w-full max-w-[880px] grow flex-col justify-between px-5 pb-10 pt-[1.87rem]"
+        className="mx-auto flex h-full w-full max-w-[37.5rem] grow flex-col justify-between px-5 pb-10 pt-[1.87rem]"
         onSubmit={handleSubmit(onSubmit)}
       >
         <div>

--- a/src/pages/ReviewCreatePage/components/ResponserSelect/index.tsx
+++ b/src/pages/ReviewCreatePage/components/ResponserSelect/index.tsx
@@ -56,7 +56,7 @@ const ResponserSelect = ({ handleClickButton }: ResponserSelectProps) => {
         onSubmit={handleSubmit(onSubmit)}
       >
         <div>
-          <h1 className="text-lg md:text-xl">응답자 선택</h1>
+          <h1 className="text-lg dark:text-white md:text-xl">응답자 선택</h1>
           <div className="flex flex-col gap-4 text-sm md:text-lg">
             {responsers.length > 0 && (
               <div className="mt-7">

--- a/src/pages/ReviewCreatePage/components/ReviewEntry/index.tsx
+++ b/src/pages/ReviewCreatePage/components/ReviewEntry/index.tsx
@@ -23,7 +23,7 @@ const ReviewEntry = ({ setReviewStep }: ReviewEntryProps) => {
 
   return (
     <form
-      className="mx-auto flex h-full w-full max-w-[880px] grow flex-col justify-between px-5 pb-10 pt-[1.87rem]"
+      className="mx-auto flex h-full w-full max-w-[37.5rem] grow flex-col justify-between px-5 pb-10 pt-[1.87rem]"
       onSubmit={handleSubmit(onSubmit)}
     >
       <div className="flex flex-col gap-[1.88rem]">

--- a/src/pages/ReviewCreatePage/components/ReviewQuestionAdder/index.tsx
+++ b/src/pages/ReviewCreatePage/components/ReviewQuestionAdder/index.tsx
@@ -45,7 +45,7 @@ const ReviewQuestionAdder = ({ setReviewStep }: ReviewQuestionAdderProps) => {
   return (
     <form
       onSubmit={handleSubmit(onSubmit)}
-      className="mx-auto flex h-full w-full max-w-[880px] grow flex-col justify-between px-5 pb-10 pt-[1.87rem]"
+      className="mx-auto flex h-full w-full max-w-[37.5rem] grow flex-col justify-between px-5 pb-10 pt-[1.87rem]"
     >
       <div className="flex flex-col gap-8">
         <div>

--- a/src/pages/ReviewCreatePage/index.tsx
+++ b/src/pages/ReviewCreatePage/index.tsx
@@ -52,12 +52,16 @@ export const ReviewCreatePage = () => {
         .map(({ receiverId }) => receiverId),
     } as const
 
-    console.log(requestData)
-
     createReview(requestData, {
       onSuccess: ({ data }) => {
-        console.log(data)
-        navigate('/')
+        if (data.success) {
+          navigate('/')
+
+          return
+        }
+
+        // TODO: 리뷰 생성에 실패하였습니다.
+        alert('리뷰 생성에 실패하였습니다.')
       },
     })
   }

--- a/src/pages/ReviewCreatePage/index.tsx
+++ b/src/pages/ReviewCreatePage/index.tsx
@@ -47,8 +47,12 @@ export const ReviewCreatePage = () => {
       description: methods.getValues('description'),
       type: 'PEER_REVIEW',
       questions: methods.getValues('questions'),
-      responserIdList: methods.getValues('responserIdList').map(({ id }) => id),
+      responserIdList: methods
+        .getValues('responserIdList')
+        .map(({ receiverId }) => receiverId),
     } as const
+
+    console.log(requestData)
 
     createReview(requestData, {
       onSuccess: ({ data }) => {

--- a/src/pages/ReviewCreatePage/types/index.ts
+++ b/src/pages/ReviewCreatePage/types/index.ts
@@ -11,10 +11,11 @@ export interface Question {
   type: QuestionType
   isRequired: boolean
   questionOptions: { optionName: string }[]
+  description: string
 }
 
 interface User {
-  id: number
+  receiverId: number
   name: string
 }
 


### PR DESCRIPTION
## 📑 구현 내용 <!-- 스크린샷, 시연 영상 및 설명 작성 -->

리뷰 생성 페이지 백엔드 api 연동했습니다.

![image](https://github.com/prgrms-web-devcourse/Team-12-ReviewRanger-FE/assets/97094709/f17bfb6e-fd92-496b-b5bd-39982753846f)
![image](https://github.com/prgrms-web-devcourse/Team-12-ReviewRanger-FE/assets/97094709/12d39a71-4e0f-4cf1-ad31-789f5513603b)
리뷰를 생성하고 나면 정상적으로 success가 response로 오는 걸 확인할 수 있습니다.


<br/>

## 🚧 참고 사항

### 페이지 너비 600px 확정!
![image](https://github.com/prgrms-web-devcourse/Team-12-ReviewRanger-FE/assets/97094709/f376692b-2a36-44cf-aee9-b6a52a1b3e92)

**페이지 너비를 max-w-[37.5rem] 으로 확정지었습니다.**


### 질문 설명 입력란 추가

![image](https://github.com/prgrms-web-devcourse/Team-12-ReviewRanger-FE/assets/97094709/f0d87208-b4ba-4186-ad8c-6689177e0bf3)

설명은 0~200자 제한이 있습니다. 즉, 꼭 설명을 작성하지 않아도 됩니다!
그리고 resize를 가능하게 해서 자유자재로 높이를 변경할 수 있도록 지정했습니다.

<br/>

<!-- ## ❓ 궁금한 점 -->
