### PR TITLE
REV-284/헤더 컴포넌트 수정

### DIFF
--- a/src/apis/hooks/useUser.ts
+++ b/src/apis/hooks/useUser.ts
@@ -20,6 +20,10 @@ const useUser = () => {
   return useQuery({
     queryKey: ['/user'],
     queryFn: getUser,
+    refetchOnMount: false,
+    refetchOnReconnect: false,
+    refetchOnWindowFocus: false,
+    staleTime: Infinity,
   })
 }
 

--- a/src/apis/hooks/useUser.ts
+++ b/src/apis/hooks/useUser.ts
@@ -20,10 +20,6 @@ const useUser = () => {
   return useQuery({
     queryKey: ['/user'],
     queryFn: getUser,
-    refetchOnMount: false,
-    refetchOnReconnect: false,
-    refetchOnWindowFocus: false,
-    staleTime: Infinity,
   })
 }
 

--- a/src/apis/hooks/useUser.ts
+++ b/src/apis/hooks/useUser.ts
@@ -2,9 +2,12 @@ import { useQuery } from '@tanstack/react-query'
 import apiClient from '@/apis/apiClient'
 
 interface User {
-  id: string
-  email: string
-  name: string
+  success: boolean
+  data: {
+    id: string
+    name: string
+    email: string
+  }
 }
 
 const useUser = () => {

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -33,7 +33,9 @@ const Header = () => {
       <div className="flex w-full items-center justify-between px-6">
         <div>
           <ArrowLeftIcon
-            className={`md:hidden" ${!goBackVisible && 'hidden'}`}
+            className={`md:hidden" ${
+              !goBackVisible && 'hidden'
+            } cursor-pointer`}
             onClick={() => navigate(-1)}
           />
         </div>

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -52,7 +52,7 @@ const Header = () => {
           <LogoRowIcon className="hidden h-11 w-60 md:block" />
         </div>
         <div>
-          {avatarVisible && data && data?.success && (
+          {avatarVisible && data?.data && (
             <div className="dropdown-hover relative">
               <div
                 className={`avatar avatar-sm flex items-center justify-center overflow-hidden border border-gray-200 bg-white md:avatar-md dark:bg-black `}

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -1,5 +1,6 @@
-import { useLocation } from 'react-router-dom'
+import { useLocation, useNavigate } from 'react-router-dom'
 import { useUser, useLogout } from '@/apis/hooks'
+
 import {
   LogoRowIcon,
   LogoShortIcon,
@@ -13,18 +14,33 @@ const Header = () => {
   const { mutate } = useLogout()
 
   const path = useLocation().pathname
+
+  const navigate = useNavigate()
+
   const avatarVisible = path !== '/sign-up' && path !== '/login'
   const goBackVisible = path !== '/login' && path !== '/'
 
+  const handleOnClickLogoArea = () => {
+    if (data && data.success) {
+      navigate('/')
+    } else {
+      navigate('/login')
+    }
+  }
+
   return (
-    <div className="sticky top-0 z-10 flex h-12 w-screen shrink-0 justify-center bg-main-red-300 py-4 md:h-20">
+    <div className="sticky top-0 z-10 flex h-12 shrink-0 justify-center bg-main-red-300 py-4 md:h-20">
       <div className="flex w-full items-center justify-between px-6">
         <div>
           <ArrowLeftIcon
             className={`md:hidden" ${!goBackVisible && 'hidden'}`}
+            onClick={() => navigate(-1)}
           />
         </div>
-        <div className="fixed left-1/2 flex -translate-x-1/2 transform items-center gap-1">
+        <div
+          onClick={handleOnClickLogoArea}
+          className="fixed left-1/2 flex -translate-x-1/2 transform cursor-pointer items-center gap-1"
+        >
           <img
             src={rangerHead}
             alt="ranger-header"
@@ -34,24 +50,43 @@ const Header = () => {
           <LogoRowIcon className="hidden h-11 w-60 md:block" />
         </div>
         <div>
-          {avatarVisible && data && (
-            <div className="dropdown z-40">
+          {avatarVisible && data && data?.success && (
+            <div className="dropdown-hover relative">
               <div
                 className={`avatar avatar-sm flex items-center justify-center overflow-hidden border border-gray-200 bg-white md:avatar-md dark:bg-black `}
               >
                 <BasicProfileIcon className="h-7 w-7 md:h-9 md:w-9" />
               </div>
-              <div className="dropdown-menu dropdown-menu-left">
-                <a className="dropdown-item text-sm">Profile</a>
-                <a tabIndex={0} className="dropdown-item text-sm">
+              <div className="dropdown-menu dropdown-menu-left-bottom w-[10rem] border-[1px] bg-[#fbfbfd] p-0 text-[0.875rem] text-[#313131] dark:border-white dark:bg-[#202020] dark:text-white">
+                <a className="dropdown-item flex items-center justify-center rounded-none border-b-[1px] border-gray-200 text-sm  dark:border-black">
+                  {data.data.name}님
+                </a>
+                <a
+                  tabIndex={0}
+                  className="dropdown-item flex items-center justify-center rounded-none border-b-[1px] border-gray-200 text-sm  dark:border-black"
+                  href="/review-creation"
+                >
                   설문만들기
                 </a>
                 <a
                   tabIndex={1}
-                  className="dropdown-item text-sm"
+                  className="dropdown-item flex items-center justify-center rounded-none border-b-[1px] border-gray-200 text-sm  dark:border-black"
+                  href="/profile"
+                >
+                  마이페이지
+                </a>
+                <a
+                  tabIndex={2}
+                  className="dropdown-item flex items-center justify-center rounded-none border-b-[1px] border-gray-200 text-sm  dark:border-black"
                   onClick={() => mutate()}
                 >
                   로그아웃
+                </a>
+                <a
+                  tabIndex={3}
+                  className="dropdown-item flex items-center justify-center border-[#37485D] text-sm dark:border-black"
+                >
+                  도움말
                 </a>
               </div>
             </div>

--- a/src/mocks/handlers/loginHandler/index.ts
+++ b/src/mocks/handlers/loginHandler/index.ts
@@ -20,9 +20,10 @@ export const loginHandlers = [
     return res(
       ctx.status(200),
       ctx.json({
-        token: jwt[rand],
-        name: '효중',
-        email: '1232@naver.com',
+        success: true,
+        data: {
+          accessToken: jwt[rand],
+        },
       }),
     )
   }),
@@ -33,9 +34,12 @@ export const loginHandlers = [
       return res(
         ctx.status(200),
         ctx.json({
-          name: '효중',
-          id: '123123',
-          email: 'asdasd@naver.com',
+          success: true,
+          data: {
+            name: '효중',
+            id: '123123',
+            email: 'asdasd@naver.com',
+          },
         }),
       )
     }

--- a/src/pages/LoginPage/index.tsx
+++ b/src/pages/LoginPage/index.tsx
@@ -1,6 +1,6 @@
 import { useNavigate } from 'react-router-dom'
 import { Header } from '@/components'
-import { useLogin } from '@/apis/hooks'
+import { useLogin, useUser } from '@/apis/hooks'
 import { TOKEN_KEY } from '@/constants'
 import { LoginGroup, LogoGroup } from './components'
 
@@ -12,6 +12,7 @@ export interface LoginProps {
 const LoginPage = () => {
   const { mutate: login } = useLogin()
   const navigate = useNavigate()
+  const { refetch } = useUser()
 
   const handleLoginButtonClick = (email: string, password: string) => {
     login(
@@ -19,6 +20,7 @@ const LoginPage = () => {
       {
         onSuccess({ data }) {
           localStorage.setItem(TOKEN_KEY, data.data.accessToken)
+          refetch()
           navigate('/')
         },
 


### PR DESCRIPTION
## 📑 구현 내용 <!-- 스크린샷, 시연 영상 및 설명 작성 -->
[chrome-capture-2023-10-22.webm](https://github.com/prgrms-web-devcourse/Team-12-ReviewRanger-FE/assets/59411107/4b25cdca-8fce-4831-bc71-4f6868d27190)

헤더 컴포넌트를 수정했습니다
크게 바뀐점은 저 왼쪽 화살표를 누르면 뒤로갈 수 있는 것과 로고를 누르면 로그인 된 사용자는 홈으로, 인증되지 않은 사용자는 로그인페이지로 이동합니다!

드롭다운에 들어가는 메뉴도 넣어놨고 링크로 연결해놨습니다.!
효리님의 컴포넌트로 갈아끼우는 게 필요할 것 같아요..!!

<br/>

## 🚧 참고 사항

<br/>

## ❓ 궁금한 점 

현재 `useUser`부분에서 쿼리 옵션을 이렇게 주고 있었는데

```ts
import { useQuery } from '@tanstack/react-query'
import apiClient from '@/apis/apiClient'

interface User {
  success: boolean
  data: {
    id: string
    name: string
    email: string
  }
}

const useUser = () => {
  const getUser = async () => {
    const user = await apiClient.get<User>('/user')

    return user.data
  }

  return useQuery({
    queryKey: ['/user'],
    queryFn: getUser,
    refetchOnMount: false,
    refetchOnReconnect: false,
    refetchOnWindowFocus: false,
    staleTime: Infinity,
  })
}

export default useUser
```

이렇게 해주면 로그인 했을 때 바로 아바타 컴포넌트가 안나타나서,,,그냥 저 옵션
을 다 뺴고 기본옵션을 주면 반영이 바로 되더라구요..!?!  왜 이런 차이가 생기는지 잘 모르겠어서...질문드립니당...


[chrome-capture-2023-10-22 (1).webm](https://github.com/prgrms-web-devcourse/Team-12-ReviewRanger-FE/assets/59411107/5fd04466-7b90-420e-baa1-a3e460c8e47f)