### PR TITLE
REV-334/유효하지않은토큰예외처리

### DIFF
--- a/src/apis/apiClient.ts
+++ b/src/apis/apiClient.ts
@@ -1,4 +1,6 @@
 import axios from 'axios'
+import { useToast } from '@/hooks'
+import { useLogout } from '@/apis/hooks'
 import { TOKEN_KEY } from '@/constants'
 
 const apiClient = axios.create({
@@ -15,6 +17,31 @@ apiClient.interceptors.request.use(
     return config
   },
   (error) => Promise.reject(error),
+)
+
+apiClient.interceptors.response.use(
+  (response) => {
+    return response
+  },
+  (error) => {
+    if (error.response && error.response.status) {
+      switch (error.response.status) {
+        case 401:
+          {
+            const { addToast } = useToast()
+            addToast({
+              message: '유효하지 않은 인증입니다! 다시 로그인을 해주세요!',
+              type: 'error',
+            })
+            const { mutate: logOut } = useLogout()
+            logOut()
+          }
+          break
+        default:
+          return Promise.reject(error)
+      }
+    }
+  },
 )
 
 export default apiClient

--- a/src/apis/hooks/useLogout.ts
+++ b/src/apis/hooks/useLogout.ts
@@ -1,4 +1,5 @@
 import { useQueryClient, useMutation } from '@tanstack/react-query'
+import { useNavigate } from 'react-router-dom'
 import { TOKEN_KEY } from '@/constants'
 import apiClient from '../apiClient'
 
@@ -8,6 +9,7 @@ interface Response {
 
 const useLogout = () => {
   const queryClient = useQueryClient()
+  const navigate = useNavigate()
   const logout = async () => {
     const response = await apiClient.post<Response>('/members/logout')
 
@@ -21,6 +23,7 @@ const useLogout = () => {
       queryClient.removeQueries({
         queryKey: ['/user'],
       })
+      navigate('/login')
     },
     //TODO - 로그아웃 실패 처리 추가 필요
   })


### PR DESCRIPTION
## 📑 구현 내용 <!-- 스크린샷, 시연 영상 및 설명 작성 -->

응답으로 토큰의 유효기간이 지난 경우 `401에러코드일떄`  인터셉터로 로그아웃을 해주는 부분을 구현했어요!

<br/>

## 🚧 참고 사항

이 브랜치에서 로그아웃 시 쿼리 키 무효화하는 것을 해도 괜찮을까용?
수연님께서 `refresh token`을 발급해주시는 대로 이 브랜치에서 작성하겠습니다.! 
<br/>

<!-- ## ❓ 궁금한 점 -->
