### PR TITLE
REV-350/리뷰 마감, 종료 시 미응답 접근 불가 처리

### DIFF
--- a/src/pages/MainPage/index.tsx
+++ b/src/pages/MainPage/index.tsx
@@ -34,6 +34,15 @@ const MainPage = () => {
   }: Pick<InvitedReview, 'reviewId' | 'participationId' | 'status'> & {
     submitStatus: boolean
   }) => {
+    if (status !== 'PROCEEDING' && !submitStatus) {
+      addToast({
+        message: '응답하지 않은 리뷰는 확인할 수 없습니다.',
+        type: 'error',
+      })
+
+      return
+    }
+
     navigate(`review-response/${reviewId}`, {
       state: {
         participationId,


### PR DESCRIPTION
## 📑 구현 내용 <!-- 스크린샷, 시연 영상 및 설명 작성 -->

리뷰 마감, 종료 시 미응답 접근 불가 처리해줬습니다.

![image](https://github.com/prgrms-web-devcourse/Team-12-ReviewRanger-FE/assets/97094709/521b58b2-05f6-4d2b-92cc-26ee24d1ef61)


근데 생각해보니 미응답하면 마감, 종료가 불가능하게 정했었네요 ,,

<br/>

## 🚧 참고 사항

<br/>

<!-- ## ❓ 궁금한 점 -->
