### PR TITLE
REV-348/모달 적용

### DIFF
--- a/src/pages/MyPage/hooks/useEditNameCheck.ts
+++ b/src/pages/MyPage/hooks/useEditNameCheck.ts
@@ -1,4 +1,4 @@
-import { Dispatch, SetStateAction, useState } from 'react'
+import { Dispatch, SetStateAction, useRef, useState } from 'react'
 import { useEditName, useUser } from '@/apis/hooks'
 import { DUPLICATED_MESSAGE } from '@/constants'
 
@@ -18,6 +18,7 @@ const useEditNameCheck = ({
   setNameFailMessage,
 }: UseEditNameCheckProps) => {
   const [editNameButton, setEditNameButton] = useState<boolean>(false)
+  const nameRef = useRef<HTMLLabelElement>(null)
   const { mutate: editName } = useEditName()
   const { refetch } = useUser()
 
@@ -27,6 +28,9 @@ const useEditNameCheck = ({
   }
 
   const handleEditNameEndingClick = () => {
+    if (nameRef.current) {
+      nameRef.current.click()
+    }
     if (currentName === name || !name) {
       setEditNameButton(false)
 
@@ -54,6 +58,7 @@ const useEditNameCheck = ({
   }
 
   return {
+    nameRef,
     editNameButton,
     handleEditNameStartingClick,
     handleEditNameEndingClick,

--- a/src/pages/MyPage/hooks/useEditNameCheck.ts
+++ b/src/pages/MyPage/hooks/useEditNameCheck.ts
@@ -1,4 +1,5 @@
 import { Dispatch, SetStateAction, useRef, useState } from 'react'
+import { useToast } from '@/hooks'
 import { useEditName, useUser } from '@/apis/hooks'
 import { DUPLICATED_MESSAGE } from '@/constants'
 
@@ -21,6 +22,7 @@ const useEditNameCheck = ({
   const nameRef = useRef<HTMLLabelElement>(null)
   const { mutate: editName } = useEditName()
   const { refetch } = useUser()
+  const { addToast } = useToast()
 
   const handleEditNameStartingClick = () => {
     setEditNameButton(true)
@@ -52,6 +54,10 @@ const useEditNameCheck = ({
           await refetch()
           setEditNameButton(false)
           setName('')
+          addToast({
+            message: '이름 변경이 완료되었습니다.',
+            type: 'success',
+          })
         },
       },
     )

--- a/src/pages/MyPage/hooks/useEditPasswordCheck.ts
+++ b/src/pages/MyPage/hooks/useEditPasswordCheck.ts
@@ -1,4 +1,5 @@
 import { useRef, useState } from 'react'
+import { useToast } from '@/hooks'
 import { useEditPassword } from '@/apis/hooks'
 
 interface UseEditPasswordCheckProps {
@@ -17,6 +18,7 @@ const useEditPasswordCheck = ({
   const [editPasswordButton, setEditPasswordButton] = useState<boolean>(false)
   const passwordRef = useRef<HTMLLabelElement>(null)
   const { mutate: editPassword } = useEditPassword()
+  const { addToast } = useToast()
 
   const handleEditPasswordStartingClick = () => {
     setEditPasswordButton(true)
@@ -37,7 +39,13 @@ const useEditPasswordCheck = ({
     editPassword(
       { password },
       {
-        onSuccess: () => setEditPasswordButton(false),
+        onSuccess: () => {
+          setEditPasswordButton(false)
+          addToast({
+            message: '비밀번호 변경이 완료되었습니다.',
+            type: 'success',
+          })
+        },
       },
     )
   }

--- a/src/pages/MyPage/hooks/useEditPasswordCheck.ts
+++ b/src/pages/MyPage/hooks/useEditPasswordCheck.ts
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useRef, useState } from 'react'
 import { useEditPassword } from '@/apis/hooks'
 
 interface UseEditPasswordCheckProps {
@@ -15,6 +15,7 @@ const useEditPasswordCheck = ({
   passwordConfirmFailMessage,
 }: UseEditPasswordCheckProps) => {
   const [editPasswordButton, setEditPasswordButton] = useState<boolean>(false)
+  const passwordRef = useRef<HTMLLabelElement>(null)
   const { mutate: editPassword } = useEditPassword()
 
   const handleEditPasswordStartingClick = () => {
@@ -22,6 +23,9 @@ const useEditPasswordCheck = ({
   }
 
   const handleEditPasswordEndingClick = () => {
+    if (passwordRef.current) {
+      passwordRef.current.click()
+    }
     if (!password && !passwordConfirm) {
       setEditPasswordButton(false)
 
@@ -39,6 +43,7 @@ const useEditPasswordCheck = ({
   }
 
   return {
+    passwordRef,
     editPasswordButton,
     handleEditPasswordStartingClick,
     handleEditPasswordEndingClick,

--- a/src/pages/MyPage/index.tsx
+++ b/src/pages/MyPage/index.tsx
@@ -1,5 +1,5 @@
 import { useNameCheck, usePasswordCheck } from '@/hooks'
-import { Header, Input } from '@/components'
+import { Header, Input, Modal } from '@/components'
 import { useUser } from '@/apis/hooks'
 import { BasicProfileIcon, CheckIcon, EditIcon } from '@/assets/icons'
 import { useEditNameCheck, useEditPasswordCheck } from './hooks'
@@ -25,6 +25,7 @@ const MyPage = () => {
   } = usePasswordCheck()
 
   const {
+    nameRef,
     editNameButton,
     handleEditNameStartingClick,
     handleEditNameEndingClick,
@@ -37,6 +38,7 @@ const MyPage = () => {
   })
 
   const {
+    passwordRef,
     editPasswordButton,
     handleEditPasswordStartingClick,
     handleEditPasswordEndingClick,
@@ -66,10 +68,9 @@ const MyPage = () => {
                 value={name}
               />
               <div className="absolute -right-8 flex h-6 w-6 items-center justify-center rounded-full border bg-white dark:bg-main-red-200">
-                <CheckIcon
-                  className="h-4 w-4 cursor-pointer fill-sub-green"
-                  onClick={handleEditNameEndingClick}
-                />
+                <label htmlFor="edit-name" ref={nameRef}>
+                  <CheckIcon className="h-4 w-4 cursor-pointer fill-sub-green" />
+                </label>
               </div>
             </div>
           ) : (
@@ -89,9 +90,8 @@ const MyPage = () => {
             {user?.email}
           </div>
         </div>
-
         {editPasswordButton ? (
-          <div className="flex flex-col items-center justify-center gap-5">
+          <form className="flex flex-col items-center justify-center gap-5">
             <Input
               className="!w-64"
               type="password"
@@ -105,12 +105,22 @@ const MyPage = () => {
               message={passwordConfirmFailMessage}
             />
             <button
-              className="h-10 w-64 max-w-xs rounded-md bg-active-orange text-lg text-white hover:border hover:border-black disabled:bg-opacity-50 dark:text-black md:text-xl"
-              onClick={handleEditPasswordEndingClick}
+              type="button"
+              className="z-10 h-10 w-64 max-w-xs rounded-md bg-active-orange text-lg text-white hover:border hover:border-black disabled:bg-opacity-50 dark:text-black md:text-xl"
             >
-              변경 완료
+              {!(passwordFailMessage || passwordConfirmFailMessage) ? (
+                <label
+                  ref={passwordRef}
+                  htmlFor="edit-password"
+                  className="flex h-full w-full items-center justify-center"
+                >
+                  변경 완료
+                </label>
+              ) : (
+                <p>변경 완료</p>
+              )}
             </button>
-          </div>
+          </form>
         ) : (
           <button
             className="h-10 w-64 max-w-xs rounded-md bg-active-orange text-lg text-white hover:border hover:border-black disabled:bg-opacity-50 dark:text-black md:text-xl"
@@ -120,6 +130,18 @@ const MyPage = () => {
           </button>
         )}
       </div>
+      <Modal
+        modalId="edit-name"
+        content={`'${name}'로 이름을 변경하시겠습니까?`}
+        label="변경"
+        handleClickLabel={handleEditNameEndingClick}
+      />
+      <Modal
+        modalId="edit-password"
+        content={`비밀번호를 변경하시겠습니까?`}
+        label="변경"
+        handleClickLabel={handleEditPasswordEndingClick}
+      />
     </div>
   )
 }

--- a/src/pages/ReviewReplyPage/components/ReceiverItem/index.tsx
+++ b/src/pages/ReviewReplyPage/components/ReceiverItem/index.tsx
@@ -41,10 +41,10 @@ const ReceiverItem = ({
                 individualReplyCompletes &&
                 index !== undefined &&
                 individualReplyCompletes[index] &&
-                'border-sub-green'
+                'border-sub-green dark:border-sub-green'
               } ${
                 (state.status === 'END' || state.status === 'DEADLINE') &&
-                'border-sub-green'
+                'border-sub-green dark:border-sub-green'
               }`}
     >
       <Profile

--- a/src/pages/ReviewReplyPage/components/ReplyCategory/ReplyDropdown/index.tsx
+++ b/src/pages/ReviewReplyPage/components/ReplyCategory/ReplyDropdown/index.tsx
@@ -54,7 +54,7 @@ const ReplyChoice = ({
   return (
     <div>
       <select
-        className="h-10 w-full rounded-md border p-2.5 text-lg"
+        className="h-10 w-full rounded-md border bg-white p-2.5 text-lg dark:bg-main-gray dark:text-white"
         value={selectedOptionId}
         {...(register(`${registerPath}.answerChoice`),
         {

--- a/src/pages/ReviewReplyPage/components/ReviewReplyEdit/ReviewReply.tsx
+++ b/src/pages/ReviewReplyPage/components/ReviewReplyEdit/ReviewReply.tsx
@@ -114,8 +114,8 @@ const ReviewReply = ({ reviewData, handleSubmit }: ReviewReplyProps) => {
       </div>
       <Modal
         modalId="review-reply"
-        content="답변을 완료하시겠습니까?"
-        label="답변 완료"
+        content="답변 수정을 완료하시겠습니까?"
+        label="수정"
         handleClickLabel={handleSubmit}
       />
     </div>

--- a/src/pages/ReviewReplyPage/components/ReviewReplyEdit/ReviewReply.tsx
+++ b/src/pages/ReviewReplyPage/components/ReviewReplyEdit/ReviewReply.tsx
@@ -1,4 +1,5 @@
 import { useFormContext } from 'react-hook-form'
+import { Modal } from '@/components'
 import { ReviewDetailedData } from '@/types'
 import { ReceiverItem, QuestionItem } from '..'
 import {
@@ -12,7 +13,7 @@ import Questions from '../Questions'
 
 interface ReviewReplyProps {
   reviewData: ReviewDetailedData
-  handleSubmit?: () => void
+  handleSubmit: () => void
 }
 
 const ReviewReply = ({ reviewData, handleSubmit }: ReviewReplyProps) => {
@@ -91,11 +92,13 @@ const ReviewReply = ({ reviewData, handleSubmit }: ReviewReplyProps) => {
       </div>
       <div className="flex justify-center md:justify-end">
         {allReplyComplete ? (
-          <button
-            onClick={handleSubmit}
-            className="mb-5 h-10 w-full rounded-md bg-active-orange text-lg text-white hover:border hover:border-black disabled:bg-opacity-50 dark:text-black md:w-52 md:text-xl"
-          >
-            답변 제출하기
+          <button className="mb-5 h-10 w-full rounded-md bg-active-orange text-lg text-white hover:border hover:border-black disabled:bg-opacity-50 dark:text-black md:w-52 md:text-xl">
+            <label
+              htmlFor="review-reply"
+              className="flex h-full w-full items-center justify-center"
+            >
+              답변 제출하기
+            </label>
           </button>
         ) : (
           <button
@@ -109,6 +112,12 @@ const ReviewReply = ({ reviewData, handleSubmit }: ReviewReplyProps) => {
           </button>
         )}
       </div>
+      <Modal
+        modalId="review-reply"
+        content="답변을 완료하시겠습니까?"
+        label="답변 완료"
+        handleClickLabel={handleSubmit}
+      />
     </div>
   )
 }

--- a/src/pages/ReviewReplyPage/components/ReviewReplyEdit/index.tsx
+++ b/src/pages/ReviewReplyPage/components/ReviewReplyEdit/index.tsx
@@ -54,12 +54,14 @@ const ReviewReplyEdit = () => {
   })
 
   useEffect(() => {
-    if (hasMounted.current) {
-      if (labelRef.current) {
-        labelRef.current.click()
-      }
-    } else {
+    if (!hasMounted.current) {
       hasMounted.current = true
+
+      return
+    }
+
+    if (labelRef.current) {
+      labelRef.current.click()
     }
   }, [])
 

--- a/src/pages/ReviewReplyPage/components/ReviewReplyEdit/index.tsx
+++ b/src/pages/ReviewReplyPage/components/ReviewReplyEdit/index.tsx
@@ -1,7 +1,8 @@
-import { useState } from 'react'
+import { useState, useRef, useEffect } from 'react'
 import { FormProvider, useForm, useFieldArray } from 'react-hook-form'
 import { useNavigate, useLocation } from 'react-router-dom'
 import { useToast } from '@/hooks'
+import { Modal } from '@/components'
 import {
   useEditResponse,
   useGetReviewForParticipation,
@@ -18,13 +19,15 @@ const ReviewReplyEdit = () => {
   const { addToast } = useToast()
   const reviewId = parseInt(pathname.split('/').at(-1) as string)
   const [initModal, setInitModal] = useState(true)
+  const labelRef = useRef<HTMLLabelElement>(null)
+  const hasMounted = useRef(false)
 
   const { data: user } = useUser()
+  const { data: reviewData } = useGetReviewForParticipation({ id: reviewId })
   const { data: prevReplyData } = useGetResponseByResponserForParticipation({
     reviewId,
     responserId: user?.id as number,
   })
-  const { data: reviewData } = useGetReviewForParticipation({ id: reviewId })
   const { mutate: editResponse } = useEditResponse()
   const { title, questions } = reviewData
 
@@ -50,8 +53,21 @@ const ReviewReplyEdit = () => {
     name: 'replyTargets',
   })
 
+  useEffect(() => {
+    if (hasMounted.current) {
+      if (labelRef.current) {
+        labelRef.current.click()
+      }
+    } else {
+      hasMounted.current = true
+    }
+  }, [])
+
   const handleClickModal = () => {
     setInitModal(false)
+    if (labelRef.current) {
+      labelRef.current.click()
+    }
     prevReplyData.forEach((receiverData) => {
       const { replies, receiver, responser } = receiverData
       const replyTarget = {
@@ -85,6 +101,10 @@ const ReviewReplyEdit = () => {
     })
   }
 
+  const handleClickCancelModal = () => {
+    navigate('/')
+  }
+
   const handleSubmitReply = () => {
     const requestData = {
       id: state.participationId,
@@ -105,19 +125,7 @@ const ReviewReplyEdit = () => {
   return (
     <div className="flex h-full w-full max-w-[37.5rem] flex-col p-5 text-black">
       <h1 className="text-lg dark:text-white md:text-2xl">{title}</h1>
-      {initModal ? (
-        <div className="flex h-full w-full items-center justify-center">
-          <div className="flex h-56 w-96 flex-col items-center justify-between rounded-md bg-gray-400 p-8">
-            <p className="whitespace-pre-wrap">{`이전에 작성한 답변이 남아 있습니다.\n계속 진행하시겠습니까?`}</p>
-            <button
-              onClick={handleClickModal}
-              className="rounded-md bg-green-300 px-4 py-2"
-            >
-              확인
-            </button>
-          </div>
-        </div>
-      ) : (
+      {!initModal && (
         <FormProvider {...methods}>
           <ReviewReply
             reviewData={reviewData}
@@ -125,6 +133,14 @@ const ReviewReplyEdit = () => {
           />
         </FormProvider>
       )}
+      <label ref={labelRef} htmlFor="review-previous-reply-load" />
+      <Modal
+        modalId="review-previous-reply-load"
+        content={`이전에 작성한 답변이 남아 있습니다.\n계속 진행하시겠습니까?`}
+        label="확인"
+        handleClickLabel={handleClickModal}
+        handleClose={handleClickCancelModal}
+      />
     </div>
   )
 }

--- a/src/pages/ReviewReplyPage/components/ReviewReplyEdit/index.tsx
+++ b/src/pages/ReviewReplyPage/components/ReviewReplyEdit/index.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react'
 import { FormProvider, useForm, useFieldArray } from 'react-hook-form'
 import { useNavigate, useLocation } from 'react-router-dom'
+import { useToast } from '@/hooks'
 import {
   useEditResponse,
   useGetReviewForParticipation,
@@ -14,6 +15,7 @@ import ReviewReply from './ReviewReply'
 const ReviewReplyEdit = () => {
   const navigate = useNavigate()
   const { pathname, state } = useLocation()
+  const { addToast } = useToast()
   const reviewId = parseInt(pathname.split('/').at(-1) as string)
   const [initModal, setInitModal] = useState(true)
 
@@ -90,7 +92,13 @@ const ReviewReplyEdit = () => {
     }
 
     editResponse(requestData, {
-      onSuccess: () => navigate('/'),
+      onSuccess: () => {
+        addToast({
+          message: '리뷰 답변 수정이 완료되었습니다.',
+          type: 'success',
+        })
+        navigate('/')
+      },
     })
   }
 

--- a/src/pages/ReviewReplyPage/components/ReviewReplyEnd/index.tsx
+++ b/src/pages/ReviewReplyPage/components/ReviewReplyEnd/index.tsx
@@ -44,12 +44,14 @@ const ReviewReplyEnd = () => {
   })
 
   useEffect(() => {
-    if (hasMounted.current) {
-      if (labelRef.current) {
-        labelRef.current.click()
-      }
-    } else {
+    if (!hasMounted.current) {
       hasMounted.current = true
+
+      return
+    }
+
+    if (labelRef.current) {
+      labelRef.current.click()
     }
   }, [])
 

--- a/src/pages/ReviewReplyPage/components/ReviewReplyStart/ReviewReply.tsx
+++ b/src/pages/ReviewReplyPage/components/ReviewReplyStart/ReviewReply.tsx
@@ -114,8 +114,8 @@ const ReviewReply = ({ reviewData, handleSubmit }: ReviewReplyProps) => {
       </div>
       <Modal
         modalId="review-reply"
-        content="답변을 완료하시겠습니까?"
-        label="답변 완료"
+        content="답변을 제출하시겠습니까?"
+        label="제출"
         handleClickLabel={handleSubmit}
       />
     </div>

--- a/src/pages/ReviewReplyPage/components/ReviewReplyStart/ReviewReply.tsx
+++ b/src/pages/ReviewReplyPage/components/ReviewReplyStart/ReviewReply.tsx
@@ -1,4 +1,5 @@
 import { useFormContext } from 'react-hook-form'
+import { Modal } from '@/components'
 import { ReviewDetailedData } from '@/types'
 import { QuestionItem, ReceiverItem } from '..'
 import {
@@ -12,7 +13,7 @@ import Questions from '../Questions'
 
 interface ReviewReplyProps {
   reviewData: ReviewDetailedData
-  handleSubmit?: () => void
+  handleSubmit: () => void
 }
 
 const ReviewReply = ({ reviewData, handleSubmit }: ReviewReplyProps) => {
@@ -91,11 +92,13 @@ const ReviewReply = ({ reviewData, handleSubmit }: ReviewReplyProps) => {
       </div>
       <div className="flex justify-center md:justify-end">
         {allReplyComplete ? (
-          <button
-            onClick={handleSubmit}
-            className="mb-5 h-10 w-full rounded-md bg-active-orange text-lg text-white hover:border hover:border-black disabled:bg-opacity-50 dark:text-black md:w-52 md:text-xl"
-          >
-            답변 제출하기
+          <button className="mb-5 h-10 w-full rounded-md bg-active-orange p-0 text-lg text-white hover:border hover:border-black disabled:bg-opacity-50 dark:text-black md:w-52 md:text-xl">
+            <label
+              htmlFor="review-reply"
+              className="flex h-full w-full items-center justify-center"
+            >
+              답변 제출하기
+            </label>
           </button>
         ) : (
           <button
@@ -109,6 +112,12 @@ const ReviewReply = ({ reviewData, handleSubmit }: ReviewReplyProps) => {
           </button>
         )}
       </div>
+      <Modal
+        modalId="review-reply"
+        content="답변을 완료하시겠습니까?"
+        label="답변 완료"
+        handleClickLabel={handleSubmit}
+      />
     </div>
   )
 }

--- a/src/pages/ReviewReplyPage/components/ReviewReplyStart/index.tsx
+++ b/src/pages/ReviewReplyPage/components/ReviewReplyStart/index.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react'
 import { FormProvider, useForm } from 'react-hook-form'
 import { useNavigate, useLocation } from 'react-router-dom'
+import { useToast } from '@/hooks'
 import { useCreateResponse, useGetReviewForParticipation } from '@/apis/hooks'
 import { ReviewReplyStartType } from '../../types'
 import ReviewReply from './ReviewReply'
@@ -8,6 +9,7 @@ import ReceiverSelect from './ReviewSelect'
 
 const ReviewReplyStart = () => {
   const navigate = useNavigate()
+  const { addToast } = useToast()
   const { pathname, state } = useLocation()
   const reviewId = parseInt(pathname.split('/').at(-1) as string)
   const [reviewStep, setReviewStep] = useState(1)
@@ -30,7 +32,13 @@ const ReviewReplyStart = () => {
     }
 
     createResponse(requestData, {
-      onSuccess: () => navigate('/'),
+      onSuccess: () => {
+        addToast({
+          message: '리뷰 답변 제출이 완료되었습니다.',
+          type: 'success',
+        })
+        navigate('/')
+      },
     })
   }
 


### PR DESCRIPTION
## 📑 구현 내용 <!-- 스크린샷, 시연 영상 및 설명 작성 -->

효리님께서 만들어주신 모달을 몇 군데 적용시켰습니다!


https://github.com/prgrms-web-devcourse/Team-12-ReviewRanger-FE/assets/88622675/81fc96b8-0654-4b81-939b-076d3d4e0963

- 초대받은 리뷰 답변 제출 시, 모달 적용
- 초대받은 리뷰 답변 수정 및, 종료된 리뷰 접근 시, 모달 적용
- 마이페이지 아이디 수정 모달 적용
- 마이페이지 비밀번호 수정 모달 적용

<br/>

## 🚧 참고 사항

초대받은 리뷰 답변 수정 및, 종료된 리뷰 접근 시, 모달 적용 부분에서 컴포넌트에 바로 들어가자마자 모달을 띄워주고 싶었습니다.
하지만 사용하고 있는 ripple ui 특성상 모달의 고유 id값을 가지고 있는 `label` 태그를 클릭해야지만 모달을 열 수 있었습니다.
이에 컴포넌트에 접속하자마자 `label` 태그를 클릭된 상태로 만들고 싶었고, `useEffect`와 `useRef`를 사용하였습니다.
하지만 strict mode 때문에 컴포넌트 렌더링 시, `useEffect`가 두 번 실행되어 `label`이 두 번 클릭되는 현상이 발생했습니다.
이에 `hasMounted`이름의 또 다른 `useRef` 변수를 사용하여 한 번만 실행되도록 구현했습니다.
```typescript
useEffect(() => {
  if (hasMounted.current) {
    if (labelRef.current) {
      labelRef.current.click()
    }
  } else {
    hasMounted.current = true
  }
}, [])
```

<hr/>

- 생성한 리뷰 관리 페이지에 모달은 아직 적용하지 못했습니다. 추후 새롭게 티켓으로 가져가면 좋을 것 같습니다.

<hr/>


- Toast도 같이 추가했습니다!

<br/>

<!-- ## ❓ 궁금한 점 -->
