### PR TITLE
REV-401/수정 시 처음에 모든 수신자들을 답변 완료처리로 변경

### DIFF
--- a/src/pages/ReviewReplyPage/components/ReviewReplyEdit/ReviewReply.tsx
+++ b/src/pages/ReviewReplyPage/components/ReviewReplyEdit/ReviewReply.tsx
@@ -46,7 +46,7 @@ const ReviewReply = ({ reviewData, handleSubmit }: ReviewReplyProps) => {
   })
 
   const { individualReplyCompletes, allReplyComplete, checkReplyComplete } =
-    useReplyComplete({ receivers, selectedReceiverIndex })
+    useReplyComplete({ receivers, selectedReceiverIndex, editPage: true })
 
   const questionArray = questions.map((question, index) => (
     <Questions

--- a/src/pages/ReviewReplyPage/hooks/useReplyComplete.ts
+++ b/src/pages/ReviewReplyPage/hooks/useReplyComplete.ts
@@ -6,16 +6,18 @@ import { ReviewReplyEditType } from '../types'
 interface UseReplyCompleteProps {
   receivers: Receiver[]
   selectedReceiverIndex: number
+  editPage?: boolean
 }
 
 const useReplyComplete = ({
   receivers,
   selectedReceiverIndex,
+  editPage = false,
 }: UseReplyCompleteProps) => {
   const [individualReplyCompletes, setIndividualReplyCompletes] = useState<
     boolean[]
-  >(Array(receivers.length).fill(false))
-  const [allReplyComplete, setAllReplyComplete] = useState<boolean>(false)
+  >(Array(receivers.length).fill(editPage))
+  const [allReplyComplete, setAllReplyComplete] = useState<boolean>(editPage)
   const { getValues } = useFormContext<ReviewReplyEditType>()
 
   const checkReplyComplete = useCallback(() => {
@@ -34,7 +36,11 @@ const useReplyComplete = ({
     setAllReplyComplete(individualReplyCompletes.every((value) => value))
   }, [individualReplyCompletes])
 
-  return { individualReplyCompletes, allReplyComplete, checkReplyComplete }
+  return {
+    individualReplyCompletes,
+    allReplyComplete,
+    checkReplyComplete,
+  }
 }
 
 export default useReplyComplete


### PR DESCRIPTION
## 📑 구현 내용 <!-- 스크린샷, 시연 영상 및 설명 작성 -->


- 1차 유저테스팅을 통해 받은 답변 페이지 피드백을 반영했습니다.
  - 수정할 때 수신자를 다시 하나하나 클릭해야 제출이 가능했던 기능을 처음 들어갔을 때, 모두 답변 완료 처리로 변경하였습니다.

<img src="https://github.com/prgrms-web-devcourse/Team-12-ReviewRanger-FE/assets/88622675/f189ee79-d2e2-4e7a-bf9c-6e338111a302" width="600" />


<br/>

## 🚧 참고 사항

<br/>

<!-- ## ❓ 궁금한 점 -->
