### PR TITLE
REV-405/답변 페이지 수신자 이미지 적용

### DIFF
--- a/src/apis/hooks/useGetResponseByResponserForParticipation.ts
+++ b/src/apis/hooks/useGetResponseByResponserForParticipation.ts
@@ -18,6 +18,7 @@ interface Reply {
 export interface User {
   id: number
   name: string
+  path: string
 }
 interface Data {
   id: number

--- a/src/components/PersonalAnswer/index.tsx
+++ b/src/components/PersonalAnswer/index.tsx
@@ -2,7 +2,7 @@ import { PropsWithChildren } from 'react'
 import { Profile } from '..'
 
 interface PersonalAnswerProps {
-  image?: string | JSX.Element
+  image?: string
   name: string
   type?: 'basic' | 'hexagon'
 }

--- a/src/components/Profile/index.tsx
+++ b/src/components/Profile/index.tsx
@@ -1,17 +1,18 @@
 import { BasicProfile } from '@/assets/images'
 
 interface ProfileProps {
-  image?: string | JSX.Element
+  image?: string
   name: string
   className?: string
 }
 
-const Profile = ({ image = BasicProfile, name, className }: ProfileProps) => {
+const Profile = ({ image, name, className }: ProfileProps) => {
   return (
     <div className="flex flex-row items-center gap-2">
-      <div className="flex h-5 w-5 items-center justify-center overflow-hidden rounded-full border bg-white dark:bg-black">
-        {typeof image === 'string' ? <img src={image} /> : image}
-      </div>
+      <img
+        src={image || BasicProfile}
+        className="flex h-5 w-5 items-center justify-center overflow-hidden rounded-full border bg-white dark:bg-black"
+      />
       <p className={`${className} text-sm dark:text-white md:text-lg`}>
         {name}
       </p>

--- a/src/components/Profile/index.tsx
+++ b/src/components/Profile/index.tsx
@@ -6,7 +6,7 @@ interface ProfileProps {
   className?: string
 }
 
-const Profile = ({ image, name, className }: ProfileProps) => {
+const Profile = ({ image = BasicProfile, name, className }: ProfileProps) => {
   return (
     <div className="flex flex-row items-center gap-2">
       <img

--- a/src/pages/ReviewReplyPage/components/ReceiverItem/index.tsx
+++ b/src/pages/ReviewReplyPage/components/ReceiverItem/index.tsx
@@ -24,8 +24,6 @@ const ReceiverItem = ({
   const { state } = useLocation()
   const { receiverId, name, path } = receiver
 
-  console.log(receiver)
-
   return (
     <li
       value={receiverId}

--- a/src/pages/ReviewReplyPage/components/ReceiverItem/index.tsx
+++ b/src/pages/ReviewReplyPage/components/ReceiverItem/index.tsx
@@ -22,7 +22,9 @@ const ReceiverItem = ({
   checkReplyComplete,
 }: ReceiverItemProps) => {
   const { state } = useLocation()
-  const { receiverId, name } = receiver
+  const { receiverId, name, path } = receiver
+
+  console.log(receiver)
 
   return (
     <li
@@ -49,6 +51,7 @@ const ReceiverItem = ({
     >
       <Profile
         name={name}
+        image={path}
         className={`${
           selectedReceiver.name === name
             ? 'text-black dark:text-white'

--- a/src/pages/ReviewReplyPage/components/ReviewReplyEdit/ReviewReply.tsx
+++ b/src/pages/ReviewReplyPage/components/ReviewReplyEdit/ReviewReply.tsx
@@ -47,7 +47,7 @@ const ReviewReply = ({ reviewData, handleSubmit }: ReviewReplyProps) => {
   })
 
   const { individualReplyCompletes, allReplyComplete, checkReplyComplete } =
-    useReplyComplete({ receivers, selectedReceiverIndex, editPage: true })
+    useReplyComplete({ receivers, selectedReceiverIndex, editing: true })
 
   useEffect(() => {
     setSelectedQuestionIndex(0)

--- a/src/pages/ReviewReplyPage/components/ReviewReplyEdit/index.tsx
+++ b/src/pages/ReviewReplyPage/components/ReviewReplyEdit/index.tsx
@@ -96,7 +96,11 @@ const ReviewReplyEdit = () => {
         ),
       }
       appendReplyTarget(replyTarget)
-      appendReceiver({ receiverId: receiver.id, name: receiver.name })
+      appendReceiver({
+        receiverId: receiver.id,
+        name: receiver.name,
+        path: receiver.path,
+      })
     })
   }
 

--- a/src/pages/ReviewReplyPage/components/ReviewReplyEnd/index.tsx
+++ b/src/pages/ReviewReplyPage/components/ReviewReplyEnd/index.tsx
@@ -87,7 +87,11 @@ const ReviewReplyEnd = () => {
         ),
       }
       appendReplyTarget(replyTarget)
-      appendReceiver({ receiverId: receiver.id, name: receiver.name })
+      appendReceiver({
+        receiverId: receiver.id,
+        name: receiver.name,
+        path: receiver.path,
+      })
     })
   }
 

--- a/src/pages/ReviewReplyPage/components/ReviewReplyStart/ReceiverList.tsx
+++ b/src/pages/ReviewReplyPage/components/ReviewReplyStart/ReceiverList.tsx
@@ -42,7 +42,7 @@ const ReceiverList = ({
               className="flex cursor-pointer items-center justify-between border-b border-gray-400 px-5 py-1.5 hover:bg-main-yellow dark:bg-gray-300 dark:hover:bg-gray-200 md:px-5 md:py-2"
               onClick={() => handleSelectReceiver(receiver)}
             >
-              <Profile name={receiver.name} />
+              <Profile name={receiver.name} image={receiver.path} />
               <CheckInTheCircleIcon
                 className={selected ? 'fill-sub-green' : 'fill-gray-100'}
               />

--- a/src/pages/ReviewReplyPage/hooks/useReplyComplete.ts
+++ b/src/pages/ReviewReplyPage/hooks/useReplyComplete.ts
@@ -6,18 +6,18 @@ import { ReviewReplyEditType } from '../types'
 interface UseReplyCompleteProps {
   receivers: Receiver[]
   selectedReceiverIndex: number
-  editPage?: boolean
+  editing?: boolean
 }
 
 const useReplyComplete = ({
   receivers,
   selectedReceiverIndex,
-  editPage = false,
+  editing = false,
 }: UseReplyCompleteProps) => {
   const [individualReplyCompletes, setIndividualReplyCompletes] = useState<
     boolean[]
-  >(Array(receivers.length).fill(editPage))
-  const [allReplyComplete, setAllReplyComplete] = useState<boolean>(editPage)
+  >(Array(receivers.length).fill(editing))
+  const [allReplyComplete, setAllReplyComplete] = useState<boolean>(editing)
   const { getValues } = useFormContext<ReviewReplyEditType>()
 
   const checkReplyComplete = useCallback(() => {

--- a/src/pages/ReviewReplyPage/types/reviewReplyEdit.ts
+++ b/src/pages/ReviewReplyPage/types/reviewReplyEdit.ts
@@ -18,6 +18,7 @@ interface ReplyTarget {
 interface User {
   receiverId: number
   name: string
+  path: string
 }
 
 interface ReplyComplete {

--- a/src/pages/ReviewReplyPage/types/reviewReplyEnd.ts
+++ b/src/pages/ReviewReplyPage/types/reviewReplyEnd.ts
@@ -17,6 +17,7 @@ interface ReplyTarget {
 interface User {
   receiverId: number
   name: string
+  path: string
 }
 
 export interface ReviewReplyEndType {

--- a/src/pages/ReviewReplyPage/types/reviewReplyStart.ts
+++ b/src/pages/ReviewReplyPage/types/reviewReplyStart.ts
@@ -16,6 +16,7 @@ interface ReplyTarget {
 export interface User {
   receiverId: number
   name: string
+  path: string
 }
 
 interface ReplyComplete {

--- a/src/types/reviewDetailed.ts
+++ b/src/types/reviewDetailed.ts
@@ -17,6 +17,7 @@ export interface Question {
 export interface Receiver {
   receiverId: number
   name: string
+  path?: string
 }
 
 export interface ReviewDetailedData {


### PR DESCRIPTION
## 📑 구현 내용 <!-- 스크린샷, 시연 영상 및 설명 작성 -->

![image](https://github.com/prgrms-web-devcourse/Team-12-ReviewRanger-FE/assets/88622675/0818916e-5189-4a90-b856-c07c17c1b5d7)

- 답변 페이지에서 유저에 프로필 사진을 추가해주었습니다

<br/>

## 🚧 참고 사항

<br/>

<!-- ## ❓ 궁금한 점 -->
